### PR TITLE
add setuptools to dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ packages = psptrace
 python_requires = >=3.8
 install_requires = psptool>=3.0
                    prettytable
+		   setuptools
 
 [options.entry_points]
 console_scripts = psptrace = psptrace.psptrace:main


### PR DESCRIPTION
installing via `pipx install .` without `setuptools` as a dependency results in
```
Traceback (most recent call last):
  File "~/.local/bin/psptrace", line 3, in <module>
    from psptrace.psptrace import main

  File "~/.local/share/pipx/venvs/psptrace/lib64/python3.13/site-packages/psptrace/__init__.py", line 3, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```